### PR TITLE
Fix media asset declaration on django 2.2+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+
+0.5.3 (unreleased)
+==================
+
+* Fix media asset declaration on django 2.2+
+
 0.5.2 (2019-01-02)
 ==================
 

--- a/aldryn_apphooks_config/widgets.py
+++ b/aldryn_apphooks_config/widgets.py
@@ -10,7 +10,7 @@ class AppHookConfigWidget(forms.Select):
     template_name = 'aldryn_apphooks_config/admin/apphook_config_widget.html'
 
     class Media:
-        js = ('js/aldryn_apphooks_config/aldryn_apphooks_config.js',)
+        js = ('admin/js/jquery.init.js', 'js/aldryn_apphooks_config/aldryn_apphooks_config.js',)
 
     def render(self, name, value, attrs=None, choices=()):
         if choices:  # pragma: no cover


### PR DESCRIPTION
Since django 2.2 form media asset dependencies must be explicitly declared
See https://docs.djangoproject.com/en/2.2/releases/2.2/#merging-of-form-media-assets